### PR TITLE
docs: fix typo in normalization strategies section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ here for clarity.
 
 # Advanced features
 The curves we provide here typically rely on their inputs to lie in a compact interval, typically [-1, 1]. So arbitrary
-inputs need to be normalized to this interval. We provide two simple out-of-the-box normalizations stragies described
+inputs need to be normalized to this interval. We provide two simple out-of-the-box normalizations strategies described
 below.
 
 ## Clamping


### PR DESCRIPTION
## Summary
- fix a typo in the "Advanced features" section of the readme

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_683ff4b9b2dc832da73bfcac1a1b0a7f