### PR TITLE
Fix normalization bug

### DIFF
--- a/src/torchcurves/_normalization.py
+++ b/src/torchcurves/_normalization.py
@@ -45,7 +45,7 @@ def clamp(x: torch.Tensor, scale: float = 1, out_min: float = -1, out_max: float
         torch.Tensor: Clamped tensor.
 
     """
-    return torch.clip(x * scale, out_min, out_max)
+    return torch.clip(x / scale, out_min, out_max)
 
 
 normalization_catalogue = {

--- a/src/torchcurves/bspline.py
+++ b/src/torchcurves/bspline.py
@@ -455,7 +455,7 @@ class BSplineCurveBase(nn.Module):
             f"knots_shape={self.knots.shape if hasattr(self, 'knots') else None})"
         )
 
-    def _prepare_arg(self, u: torch.Tensor) -> Tuple[torch.Size, torch.Tensor]:
+    def _prepare_arg(self, u: torch.Tensor) -> torch.Tensor:
         return self.normalize_fn(u, self.normalization_scale, out_min=self._knot_min, out_max=self._knot_max)
 
     def forward(self, u: torch.Tensor):


### PR DESCRIPTION
## Summary
- correct clamp normalization scaling
- fix `_prepare_arg` return type

## Testing
- `pytest -q -o addopts=""` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683ff3f54858832da2c0c9902a743665