### PR TITLE
Fix default knot device and dtype

### DIFF
--- a/src/torchcurves/bspline.py
+++ b/src/torchcurves/bspline.py
@@ -510,7 +510,9 @@ def bspline_curves(
     """
     if knots is None:
         n_control_points = control_points.shape[1]
-        knots = uniform_augmented_knots(n_control_points, degree)
+        knots = uniform_augmented_knots(
+            n_control_points, degree, dtype=control_points.dtype, device=control_points.device
+        )
 
     return BSplineFunction.apply(
         u,
@@ -546,7 +548,9 @@ def bspline_embeddings(
     """
     n_control_points = control_points.shape[1]
     if knots is None:
-        knots = uniform_augmented_knots(n_control_points, degree)
+        knots = uniform_augmented_knots(
+            n_control_points, degree, dtype=control_points.dtype, device=control_points.device
+        )
 
     spans = BSplineFunction.find_spans(u, knots, degree, n_control_points)  # (N,M)
     basis_funcs = BSplineFunction.cox_de_boor(u, knots, spans, degree)  # (N,M,deg+1)

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from torchcurves.bspline import BSplineCurve, BSplineFunction
+from torchcurves.bspline import BSplineCurve, BSplineFunction, bspline_curves
 
 
 class TestBSplineFunction(unittest.TestCase):
@@ -615,6 +615,22 @@ class TestBSplineCurveModule(unittest.TestCase):
         loss.backward()
         self.assertIsNotNone(module_cuda.control_points.grad)
         self.assertEqual(module_cuda.control_points.grad.device.type, "cuda")
+
+
+def test_bspline_curves_default_knots_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available, skipping test.")
+
+    dtype = torch.float64
+    device = torch.device("cuda")
+
+    control_points = torch.randn(1, 4, 1, dtype=dtype, device=device)
+    u = torch.linspace(-1, 1, 5, dtype=dtype, device=device).unsqueeze(1)
+
+    result = bspline_curves(u, control_points, knots=None, degree=3)
+
+    assert result.device == device
+    assert result.dtype == dtype
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `uniform_augmented_knots` uses control points dtype/device
- add CUDA test verifying the behaviour

## Testing
- `pytest -v -o addopts=""` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683ff4b58934832d83f195e1d23e3a33