### PR TITLE
Stabilize Read the Docs uv environment setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,24 +8,16 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.12"
+  apt_packages:
+    - pandoc
+  commands:
+    - python -m pip install --upgrade pip
+    - python -m pip install --upgrade uv
+    - python -m uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" python -m uv sync --frozen --group doc dev examples
 
-# Build documentation in the "docs/" directory with Sphinx
+# Build documentation in the "doc/" directory with Sphinx
 sphinx:
-   configuration: doc/source/conf.py
+  configuration: doc/source/conf.py
 
-jobs:
-    # Install uv via asdf
-    pre_create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-
-    # Create the exact venv path RTD expects
-    create_environment:
-      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-
-    # Install your project + docs extras using uv
-    install:
-      # If you use uv's lockfile, keep --frozen. Remove it if you don't commit uv.lock.
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group doc dev examples


### PR DESCRIPTION
## Summary
- install pandoc via apt, upgrade pip/uv, and create the Read the Docs virtual environment before syncing dependencies with uv
- sync the doc, dev, and examples dependency groups into the hosted environment via `uv sync`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d80f1fb024832dba2f41b0282530f0